### PR TITLE
Updated Automatic installation URL for Windows

### DIFF
--- a/projects/stats/README.md
+++ b/projects/stats/README.md
@@ -54,7 +54,7 @@ sh <(curl -s https://raw.githubusercontent.com/harbassan/spicetify-apps/main/sta
 ### Automatic Installation (Windows, Powershell)
 
 ```ps1
-iwr -useb "https://raw.githubusercontent.com/harbassan/spicetify-apps/main/stats/install.ps1" | iex
+iwr -useb "https://raw.githubusercontent.com/harbassan/spicetify-apps/refs/heads/main/projects/stats/install.ps1" | iex
 ```
 
 ### Manual Installation


### PR DESCRIPTION
fixed url for Automatic installation URL for Windows(powershell)
Old URL returned error 404