### PR TITLE
fix(stats): automatic installation URL for Linux

### DIFF
--- a/projects/stats/README.md
+++ b/projects/stats/README.md
@@ -48,7 +48,7 @@
 ### Automatic Installation (Linux)
 
 ```sh
-sh <(curl -s https://raw.githubusercontent.com/harbassan/spicetify-apps/main/stats/install.sh)
+sh <(curl -s https://raw.githubusercontent.com/harbassan/spicetify-apps/refs/heads/main/projects/stats/install.sh)
 ```
 
 ### Automatic Installation (Windows, Powershell)


### PR DESCRIPTION
Fix for the issue (#239) I created

`/refs/heads/` isn't required for the URL to be correct, but I still added it for consistency with the windows URL